### PR TITLE
Refactor/break up app

### DIFF
--- a/src/components/AllEpisodes/AllEpisodes.tsx
+++ b/src/components/AllEpisodes/AllEpisodes.tsx
@@ -2,21 +2,91 @@ import './AllEpisodes.css';
 import { CleanEpisode } from '../../interfaces';
 import { Row } from '../Row/Row';
 import { Form } from '../Form/Form';
+import { useEffect, useState } from 'react';
 
 export const AllEpisodes = ({
-    filteredEpisodes, 
-    handleRowClick, 
-    handleSort, 
+    episodes,
     handleWatchList,
-    handleSearch
+    handleRowClick,
     }:{ 
-    filteredEpisodes: CleanEpisode[],
-    handleRowClick: (id: number) => void,
-    handleSort: (sortBy: string, sortOrder: string) => void,
+    episodes: CleanEpisode[],
     handleWatchList: (id: number) => void,
-    handleSearch: (search: string) => void
+    handleRowClick: (id: number) => void,
     }) => {
+
+    const [searchInput, setSearchInput] = useState<string>('')
+    const [filteredEpisodes, setFilteredEpisodes] = useState<CleanEpisode[]>([])    
+
+    useEffect(() => {
+        setFilteredEpisodes(episodes)
+      }, [episodes])
+
+    useEffect(() => {
+        setFilteredEpisodes(episodes.filter(episode => {
+          return episode.title.toLowerCase().includes(searchInput.toLowerCase())
+        }))
+    }, [searchInput])
+
+    const sortBySeasonOrEpisode = (sortBy: string, sortOrder: string) => {
+        return filteredEpisodes.sort((a, b) => {
+          if (sortOrder === 'ascending') {
+            return parseInt(a[sortBy]) - parseInt(b[sortBy])
+          } else {
+            return parseInt(b[sortBy]) - parseInt(a[sortBy])
+          }
+        })
+    }
     
+    const sortByTitle = (sortOrder: string) => {
+    return filteredEpisodes.sort((a, b) => {
+        if (sortOrder === 'ascending') {
+        return a.title > b.title ? 1 : -1
+        } else {
+        return a.title > b.title ? -1 : 1
+        }
+    })
+    }
+
+    const sortByWatch = (sortOrder: string) => {
+    return filteredEpisodes.sort((a, b) => {
+        if (sortOrder === 'ascending') {
+        return a.watchList > b.watchList ? -1 : 1
+        } else {
+        return a.watchList >= b.watchList ? 1 : -1
+        }
+    })
+    }
+    
+    const sortByDate = (sortOrder: string) => {
+    return filteredEpisodes.sort((a, b) => {
+        let aDate = new Date(a.airDate.replace('-', '/').replace('-', '/'))
+        let bDate = new Date(b.airDate.replace('-', '/').replace('-', '/'))
+        if (sortOrder === 'ascending') {
+        return aDate > bDate ? 1 : -1
+        } else {
+        return aDate > bDate ? -1 : 1
+        }
+    })
+    }
+
+    const handleSort = (sortBy: string, sortOrder: string) => {
+    let newSort;
+    if (sortBy === 'season' || sortBy === 'episode') {
+        newSort = sortBySeasonOrEpisode(sortBy, sortOrder)
+    } else if (sortBy === 'title') {
+        newSort = sortByTitle(sortOrder)
+    } else if (sortBy === 'watchList') {
+        newSort = sortByWatch(sortOrder)
+    } else {
+        newSort = sortByDate(sortOrder)
+    }
+    setFilteredEpisodes([...newSort])
+    }
+
+    const handleSearch = (search: string) => {
+    setSearchInput(search)
+    }
+
     const tableRows = filteredEpisodes.map(episode => {
         return (
             <Row
@@ -30,6 +100,7 @@ export const AllEpisodes = ({
 
     return(
         <>
+            <h3>All Episodes</h3>
             <Form handleSort={handleSort} handleSearch={handleSearch}/>
             <div className="container-all-episodes">
                 <table className="table">

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -118,6 +118,7 @@ const [clicked, setClicked] = useState<string>('All Episodes')
     
   useEffect(() => {
     setFilteredEpisodes(episodes.filter(episode => {
+      
       return episode.title.toLowerCase().includes(searchInput.toLowerCase())
     }))
   },[searchInput])

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -29,6 +29,10 @@ const [clicked, setClicked] = useState<string>('All Episodes')
     })
   },[])
 
+  useEffect(() => {
+    setFilteredEpisodes(episodes)
+  }, [episodes])
+
   const handleRowClick = (id: number) => {
     const singleEpisode = filteredEpisodes.find(episode => {
       return episode.id === id;
@@ -37,7 +41,7 @@ const [clicked, setClicked] = useState<string>('All Episodes')
   }
 
   const handleWatchList = (id: number | undefined) => {
-    const updatedEpisodes = filteredEpisodes.map(episode => {
+    const updatedEpisodes = episodes.map(episode => {
       if (episode.id === id) {
         return {
           ...episode,
@@ -47,11 +51,11 @@ const [clicked, setClicked] = useState<string>('All Episodes')
       return episode
     })
 
-    setFilteredEpisodes([...updatedEpisodes])
+    setEpisodes([...updatedEpisodes])
   }
 
   const handleDetailsWatch = (id: number) => {
-    setDetailEpisode(filteredEpisodes.find(episode => episode.id === id))
+    setDetailEpisode(episodes.find(episode => episode.id === id))
   }
 
   const sortBySeasonOrEpisode = (sortBy: string, sortOrder: string) => {
@@ -77,22 +81,20 @@ const [clicked, setClicked] = useState<string>('All Episodes')
   const sortByWatch = (sortOrder: string) => {
     return filteredEpisodes.sort((a, b) => {
     if (sortOrder === 'ascending') {
-      return a.watchList > b.watchList ? -1 : 1
+      return a.watchList >= b.watchList ? 1 : -1
     } else {
-      return a.watchList > b.watchList ? 1 : -1
+      return a.watchList > b.watchList ? -1 : 1
       }
     })
   }
 
   const sortByDate = (sortOrder: string) => {
     return filteredEpisodes.sort((a, b) => {
+      let aDate = new Date(a.airDate.replace('-', '/').replace('-', '/'))
+      let bDate = new Date(b.airDate.replace('-', '/').replace('-', '/'))
       if (sortOrder === 'ascending') {
-        let aDate = new Date(a.airDate.replace('-', '/').replace('-', '/'))
-        let bDate = new Date(b.airDate.replace('-', '/').replace('-', '/'))
         return aDate > bDate ? 1 : -1
       } else {
-        let aDate = new Date(a.airDate.replace('-', '/').replace('-', '/'))
-        let bDate = new Date(b.airDate.replace('-', '/').replace('-', '/'))
         return aDate > bDate ? -1 : 1
       }
     })
@@ -118,13 +120,12 @@ const [clicked, setClicked] = useState<string>('All Episodes')
     
   useEffect(() => {
     setFilteredEpisodes(episodes.filter(episode => {
-      
       return episode.title.toLowerCase().includes(searchInput.toLowerCase())
     }))
   },[searchInput])
 
   const handleReflectionChange = (event: any, id: number | undefined) => {
-    const updatedEpisodes = filteredEpisodes.map(episode => {
+    const updatedEpisodes = episodes.map(episode => {
       if (episode.id === id) {
         return {
           ...episode,
@@ -134,7 +135,7 @@ const [clicked, setClicked] = useState<string>('All Episodes')
       return episode
     })
 
-    setFilteredEpisodes([...updatedEpisodes])
+    setEpisodes([...updatedEpisodes])
   }
 
   return(

--- a/src/components/App/App.tsx
+++ b/src/components/App/App.tsx
@@ -12,33 +12,19 @@ import { Routes, Route, NavLink, Link } from 'react-router-dom';
 
 
 const App = () => {
-const [episodes, setEpisodes] = useState<CleanEpisode[]>([])
-const [detailEpisode, setDetailEpisode] = useState<CleanEpisode>()
-const [searchInput, setSearchInput] = useState<string>('')
-const [filteredEpisodes, setFilteredEpisodes] = useState<CleanEpisode[]>([])
-const [clicked, setClicked] = useState<string>('All Episodes')
+  const [episodes, setEpisodes] = useState<CleanEpisode[]>([])
+  const [detailEpisode, setDetailEpisode] = useState<CleanEpisode>()
+  const [clicked, setClicked] = useState<string>('All Episodes')
 
   useEffect(() => {
     fetchEpisodes()
       .then(data => {
         setEpisodes(cleanEpisodes(data))
-        setFilteredEpisodes(cleanEpisodes(data))
       })
       .catch((response) => {
         console.log(response.status)
-    })
-  },[])
-
-  useEffect(() => {
-    setFilteredEpisodes(episodes)
-  }, [episodes])
-
-  const handleRowClick = (id: number) => {
-    const singleEpisode = filteredEpisodes.find(episode => {
-      return episode.id === id;
-    })
-    setDetailEpisode(singleEpisode)
-  }
+      })
+  }, [])
 
   const handleWatchList = (id: number | undefined) => {
     const updatedEpisodes = episodes.map(episode => {
@@ -54,75 +40,16 @@ const [clicked, setClicked] = useState<string>('All Episodes')
     setEpisodes([...updatedEpisodes])
   }
 
-  const handleDetailsWatch = (id: number) => {
+  const handleRowClick = (id: number) => {
+    const singleEpisode = episodes.find(episode => {
+      return episode.id === id;
+    })
+    setDetailEpisode(singleEpisode)
+  }
+
+  const handleDetailsUpdate = (id: number) => {
     setDetailEpisode(episodes.find(episode => episode.id === id))
   }
-
-  const sortBySeasonOrEpisode = (sortBy: string, sortOrder: string) => {
-    return filteredEpisodes.sort((a, b) => {
-        if (sortOrder === 'ascending') {
-          return parseInt(a[sortBy]) - parseInt(b[sortBy])
-        } else {
-          return parseInt(b[sortBy]) - parseInt(a[sortBy])
-        }
-    })
-  }
-
-  const sortByTitle = (sortOrder: string) => {
-    return filteredEpisodes.sort((a, b) => {
-    if (sortOrder === 'ascending') {
-      return a.title > b.title ? 1 : -1
-    } else {
-      return a.title > b.title ? -1 : 1
-      }
-    })
-  }
-
-  const sortByWatch = (sortOrder: string) => {
-    return filteredEpisodes.sort((a, b) => {
-    if (sortOrder === 'ascending') {
-      return a.watchList >= b.watchList ? 1 : -1
-    } else {
-      return a.watchList > b.watchList ? -1 : 1
-      }
-    })
-  }
-
-  const sortByDate = (sortOrder: string) => {
-    return filteredEpisodes.sort((a, b) => {
-      let aDate = new Date(a.airDate.replace('-', '/').replace('-', '/'))
-      let bDate = new Date(b.airDate.replace('-', '/').replace('-', '/'))
-      if (sortOrder === 'ascending') {
-        return aDate > bDate ? 1 : -1
-      } else {
-        return aDate > bDate ? -1 : 1
-      }
-    })
-  }
-
-  const handleSort = (sortBy: string, sortOrder: string) => {
-    let newSort; 
-    if (sortBy === 'season' || sortBy === 'episode') {
-        newSort = sortBySeasonOrEpisode(sortBy, sortOrder)
-      } else if (sortBy === 'title') {
-        newSort = sortByTitle(sortOrder)
-      } else if (sortBy === 'watchList') {
-        newSort = sortByWatch(sortOrder)
-      } else {
-        newSort = sortByDate(sortOrder)
-      }
-      setFilteredEpisodes([...newSort])
-    }
-
-  const handleSearch = (search: string) => {
-    setSearchInput(search)
-  }
-    
-  useEffect(() => {
-    setFilteredEpisodes(episodes.filter(episode => {
-      return episode.title.toLowerCase().includes(searchInput.toLowerCase())
-    }))
-  },[searchInput])
 
   const handleReflectionChange = (event: any, id: number | undefined) => {
     const updatedEpisodes = episodes.map(episode => {
@@ -138,7 +65,7 @@ const [clicked, setClicked] = useState<string>('All Episodes')
     setEpisodes([...updatedEpisodes])
   }
 
-  return(
+  return (
     <>
       <header>
         <h1>You’ve just crossed over into…</h1>
@@ -150,28 +77,25 @@ const [clicked, setClicked] = useState<string>('All Episodes')
       </header>
       <main>
         <div className="container-left">
-          <h3>{clicked}</h3>
           <Routes>
             <Route path="/" element={
-              <AllEpisodes 
-                filteredEpisodes={filteredEpisodes} 
-                handleRowClick={handleRowClick} 
-                handleSort={handleSort}
-                handleWatchList={handleWatchList}  
-                handleSearch={handleSearch}
-              />}/>
-            <Route path="watch-list" element={
-              <WatchList 
-                filteredEpisodes={filteredEpisodes}
+              <AllEpisodes
+                episodes={episodes}
                 handleWatchList={handleWatchList}
                 handleRowClick={handleRowClick}
-              />}/>
+              />} />
+            <Route path="watch-list" element={
+              <WatchList
+                episodes={episodes}
+                handleWatchList={handleWatchList}
+                handleRowClick={handleRowClick}
+              />} />
           </Routes>
         </div>
-        <Details 
-          detailEpisode={detailEpisode} 
-          filteredEpisodes={filteredEpisodes}
-          handleDetailsWatch={handleDetailsWatch}  
+        <Details
+          detailEpisode={detailEpisode}
+          episodes={episodes}
+          handleDetailsUpdate={handleDetailsUpdate}
           handleReflectionChange={handleReflectionChange}
           handleWatchList={handleWatchList}
         />

--- a/src/components/Details/Details.css
+++ b/src/components/Details/Details.css
@@ -4,6 +4,9 @@
     height: 95%;
     box-shadow: 8px 8px 8px rgb(69, 69, 69);
     background-color:rgb(242, 242, 242);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .message-no-episode {
@@ -11,6 +14,7 @@
     font-size: 24px;
     font-weight: 500;
     margin-top: 15%;
+    width: 50%;
 }
 
 .img-no-episode {

--- a/src/components/Details/Details.css
+++ b/src/components/Details/Details.css
@@ -1,3 +1,25 @@
+.message-details {
+    border: solid black 2px;
+    width: 47.5%;
+    height: 95%;
+    box-shadow: 8px 8px 8px rgb(69, 69, 69);
+    background-color:rgb(242, 242, 242);
+}
+
+.message-no-episode {
+    text-align: center;
+    font-size: 24px;
+    font-weight: 500;
+    margin-top: 15%;
+}
+
+.img-no-episode {
+    width: 40%;
+    border-radius: 20%;
+    margin-top: 5%;
+    box-shadow: 8px 8px 8px rgb(69, 69, 69);
+}
+
 .container-details {
     border: solid black 2px;
     width: 47.5%;

--- a/src/components/Details/Details.tsx
+++ b/src/components/Details/Details.tsx
@@ -5,22 +5,22 @@ import noEpisode from '../../images/no-episode.gif';
 
 export const Details = ({
     detailEpisode,
-    filteredEpisodes,
-    handleDetailsWatch,
+    episodes,
+    handleDetailsUpdate,
     handleReflectionChange,
     handleWatchList
     }:{ 
     detailEpisode: CleanEpisode | undefined,
-    filteredEpisodes: CleanEpisode[],
-    handleDetailsWatch: (id: number) => void,
+    episodes: CleanEpisode[],
+    handleDetailsUpdate: (id: number) => void,
     handleReflectionChange: (event: any, id: number | undefined) => void,
     handleWatchList: (id: number | undefined) => void
     }) => {
     const cast = detailEpisode?.cast.join(', ')
 
     useEffect(() => {
-        detailEpisode && handleDetailsWatch(detailEpisode.id)
-    },[filteredEpisodes])
+        detailEpisode && handleDetailsUpdate(detailEpisode.id)
+    },[episodes])
 
     return(
         <>

--- a/src/components/Details/Details.tsx
+++ b/src/components/Details/Details.tsx
@@ -24,11 +24,11 @@ export const Details = ({
 
     return(
         <>
-            {!detailEpisode && <div className="message-details">
+            {!detailEpisode ? <div className="message-details">
                 <p className="message-no-episode">Select an episode to see the details and add your own reflection!</p>
                 <img className="img-no-episode" src={noEpisode}/>
-            </div>}
-            {detailEpisode && <div className="container-details">
+            </div> : null}
+            {detailEpisode ? <div className="container-details">
                 <div className="container-watch">
                     <label htmlFor="watchList">On Watch List:</label>
                     <input  className="checkbox" id="watchList" type="checkbox" onClick={() => handleWatchList(detailEpisode?.id)} checked={detailEpisode?.watchList}/>
@@ -58,7 +58,7 @@ export const Details = ({
                         <textarea rows={15} value={detailEpisode?.reflection} onChange={(event) => handleReflectionChange(event, detailEpisode?.id)}></textarea>
                     </div>
                 </div>
-            </div>}
+            </div> : null}
         </>
     )
 }

--- a/src/components/Details/Details.tsx
+++ b/src/components/Details/Details.tsx
@@ -1,6 +1,7 @@
 import './Details.css';
 import { CleanEpisode } from '../../interfaces';
 import { useEffect } from 'react';
+import noEpisode from '../../images/no-episode.gif';
 
 export const Details = ({
     detailEpisode,
@@ -22,36 +23,42 @@ export const Details = ({
     },[filteredEpisodes])
 
     return(
-        <div className="container-details">
-            <div className="container-watch">
-                <label htmlFor="watchList">On Watch List:</label>
-                <input  className="checkbox" id="watchList" type="checkbox" onClick={() => handleWatchList(detailEpisode?.id)} checked={detailEpisode?.watchList}/>
-            </div>
-            <div className="container-img-title">
-                <img src={detailEpisode?.img} className="image"/>
-                <div className="title-info">
-                    <p className="title">{detailEpisode?.title}</p>
-                    <div className="season-episode-date">
-                        <p><strong>Season:</strong> {detailEpisode?.season}</p>
-                        <p><strong>Episode:</strong> {detailEpisode?.episode}</p>
-                        <p><strong>Original Air Date:</strong> {detailEpisode?.airDate}</p>
+        <>
+            {!detailEpisode && <div className="message-details">
+                <p className="message-no-episode">Select an episode to see the details and add your own reflection!</p>
+                <img className="img-no-episode" src={noEpisode}/>
+            </div>}
+            {detailEpisode && <div className="container-details">
+                <div className="container-watch">
+                    <label htmlFor="watchList">On Watch List:</label>
+                    <input  className="checkbox" id="watchList" type="checkbox" onClick={() => handleWatchList(detailEpisode?.id)} checked={detailEpisode?.watchList}/>
+                </div>
+                <div className="container-img-title">
+                    <img src={detailEpisode?.img} className="image"/>
+                    <div className="title-info">
+                        <p className="title">{detailEpisode?.title}</p>
+                        <div className="season-episode-date">
+                            <p><strong>Season:</strong> {detailEpisode?.season}</p>
+                            <p><strong>Episode:</strong> {detailEpisode?.episode}</p>
+                            <p><strong>Original Air Date:</strong> {detailEpisode?.airDate}</p>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div className="container-info">
-                <div className="written-cast">
-                    <p className="written"><strong>Written By:</strong> {detailEpisode?.writtenBy}</p>
-                    <p className="cast"><strong>Cast:</strong> {cast}</p>
+                <div className="container-info">
+                    <div className="written-cast">
+                        <p className="written"><strong>Written By:</strong> {detailEpisode?.writtenBy}</p>
+                        <p className="cast"><strong>Cast:</strong> {cast}</p>
+                    </div>
+                    <div><strong>Storyline:</strong> <p className="text">{detailEpisode?.storyline}</p></div>
+                    <div><strong>Opening Narration:</strong> <p className="text">{detailEpisode?.openingNarration}</p></div>
+                    <div><strong>Closing Narration:</strong> <p className="text spoiler">{detailEpisode?.closingNarration}</p></div>
+                    <div><strong>Wikipedia Link:</strong> <a target="_blank" href={detailEpisode?.wikipedia}>{detailEpisode?.wikipedia}</a></div>
+                    <div className="container-reflection">
+                        <p><strong>Add/Edit Your Own Reflection:</strong></p>
+                        <textarea rows={15} value={detailEpisode?.reflection} onChange={(event) => handleReflectionChange(event, detailEpisode?.id)}></textarea>
+                    </div>
                 </div>
-                <div><strong>Storyline:</strong> <p className="text">{detailEpisode?.storyline}</p></div>
-                <div><strong>Opening Narration:</strong> <p className="text">{detailEpisode?.openingNarration}</p></div>
-                <div><strong>Closing Narration:</strong> <p className="text spoiler">{detailEpisode?.closingNarration}</p></div>
-                <div><strong>Wikipedia Link:</strong> <a target="_blank" href={detailEpisode?.wikipedia}>{detailEpisode?.wikipedia}</a></div>
-                <div className="container-reflection">
-                    <p><strong>Add/Edit Your Own Reflection:</strong></p>
-                    <textarea rows={15} value={detailEpisode?.reflection} onChange={(event) => handleReflectionChange(event, detailEpisode?.id)}></textarea>
-                </div>
-            </div>
-        </div>
+            </div>}
+        </>
     )
 }

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -26,6 +26,9 @@ export const Form = ({ handleSort, handleSearch }:{ handleSort: (sortBy: string,
     }
 
     useEffect(() => {
+        if (sortBy === 'sort by') {
+            return;
+        }
         handleSort(sortBy, sortOrder)
     },[sortBy, sortOrder])
 

--- a/src/components/WatchList/WatchList.css
+++ b/src/components/WatchList/WatchList.css
@@ -1,3 +1,24 @@
 .container-watch-list {
     overflow-y: scroll;
 }
+
+.container-message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.message-no-watch {
+    text-align: center;
+    font-size: 24px;
+    font-weight: 500;
+    margin-top: 8%;
+    width: 50%;
+}
+
+.img-no-watch {
+    width: 40%;
+    border-radius: 20%;
+    margin-top: 5%;
+    box-shadow: 8px 8px 8px rgb(69, 69, 69);
+}

--- a/src/components/WatchList/WatchList.css
+++ b/src/components/WatchList/WatchList.css
@@ -1,5 +1,6 @@
 .container-watch-list {
     overflow-y: scroll;
+    height: 100%;
 }
 
 .container-message {

--- a/src/components/WatchList/WatchList.tsx
+++ b/src/components/WatchList/WatchList.tsx
@@ -4,16 +4,16 @@ import { WatchCard } from '../WatchCard/WatchCard';
 import noWatch from '../../images/no-episode.gif';
 
 export const WatchList = ({
-    filteredEpisodes,
+    episodes,
     handleWatchList,
     handleRowClick
 }: {
-    filteredEpisodes: CleanEpisode[],
+    episodes: CleanEpisode[],
     handleWatchList: (id: number) => void,
     handleRowClick: (id: number) => void
 }) => {
 
-    const watchList = filteredEpisodes.filter(episode => episode.watchList)
+    const watchList = episodes.filter(episode => episode.watchList)
     const watchCards = watchList.map(episode => {
         return (
             <WatchCard
@@ -27,6 +27,7 @@ export const WatchList = ({
     return (
         <>
             <div className="container-watch-list">
+                <h3>My Watch List</h3>
                 {!watchCards.length ? <div className="container-message">
                     <p className="message-no-watch">Add episodes to your watch list to view them here!</p>
                     <img className="img-no-watch" src={noWatch} />

--- a/src/components/WatchList/WatchList.tsx
+++ b/src/components/WatchList/WatchList.tsx
@@ -1,15 +1,14 @@
 import './WatchList.css';
 import { CleanEpisode } from '../../interfaces';
 import { WatchCard } from '../WatchCard/WatchCard';
-import { Console } from 'console';
-import { watch } from 'fs';
+import noWatch from '../../images/no-episode.gif';
 
 export const WatchList = ({
-    filteredEpisodes, 
+    filteredEpisodes,
     handleWatchList,
     handleRowClick
-    }:{ 
-    filteredEpisodes: CleanEpisode[], 
+}: {
+    filteredEpisodes: CleanEpisode[],
     handleWatchList: (id: number) => void,
     handleRowClick: (id: number) => void
 }) => {
@@ -17,17 +16,23 @@ export const WatchList = ({
     const watchList = filteredEpisodes.filter(episode => episode.watchList)
     const watchCards = watchList.map(episode => {
         return (
-            <WatchCard 
-                cardProps={episode} 
+            <WatchCard
+                cardProps={episode}
                 handleWatchList={handleWatchList}
                 handleRowClick={handleRowClick}
                 key={episode.id}
-                />
+            />
         )
     })
-    return(
-        <div className="container-watch-list">
-            {watchCards}
-        </div>
+    return (
+        <>
+            <div className="container-watch-list">
+                {!watchCards.length ? <div className="container-message">
+                    <p className="message-no-watch">Add episodes to your watch list to view them here!</p>
+                    <img className="img-no-watch" src={noWatch} />
+                </div> : null}
+                {watchCards}
+            </div>
+        </>
     )
 }


### PR DESCRIPTION
What does this PR do?
- The `App` component was holding too much state and handling too many actions, so this PR thins app out and makes the code more modular throughout.
- Essentially `episodes` is the source of truth now. Any change to `watchList` or `reflection` is made to `episodes` and that flows to `filteredEpisodes`. Any change to sorting or search only effects `filteredEpisodes`.

What (if any) features are you implementing
- No new features

What (if any) bug fixes are you implementing
- No bug fixes

What (if anything) did you refactor?
- Sorting state and functionality was moved from`App` to `AllEpisodes`
- Searching state and functionality was moved from `App` to `AllEpisodes`
- `filtereredEpisodes` now lives inside of AllEpisodes. Any time `episodes` is updated, `filteredEpisodes` is then updated with a `useEffect`

